### PR TITLE
Fix requirements.txt and add docker option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,30 @@
-FROM ubuntu:22.04
+FROM ghcr.io/nerfstudio-project/nerfstudio:1.1.3
 ARG DEBIAN_FRONTEND=noninteractive
 
+# get the source
+COPY . /SplatGym
+
 # Install dependencies
-RUN apt update && apt install -y python3 python3-pip git build-essential cmake libpcl-dev liboctomap-dev libeigen3-dev pybind11-dev libfcl-dev libccd-dev
-
-
-# Clone the repository
-RUN git clone https://github.com/SplatLearn/SplatGym.git
-RUN git clone https://github.com/SplatLearn/collision_detector.git
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip git build-essential \
+    cmake libpcl-dev liboctomap-dev \
+    libeigen3-dev pybind11-dev libfcl-dev \
+    libccd-dev swig && \
+    apt-get clean
 
 # Build the collision detector
-RUN mkdir -p collision_detector/build && cd collision_detector/build && cmake ../pcd2bt && make -j
+RUN git clone https://github.com/SplatLearn/collision_detector.git && \
+    mkdir -p collision_detector/build && \
+    cd collision_detector/build && \
+    cmake ../pcd2bt && make -j && \
+    cp pybind_collision_detector.cpython*.so /SplatGym/src && \
+    rm -rf /collision_detector
 
 # Install the requirements
-RUN pip3 install -r SplatGym/requirements.txt
+RUN pip3 --no-cache-dir install -r SplatGym/requirements.txt
+
+# Set the environment variables
+ENV PYTHONPATH="${PYTHONPATH}:/SplatGym/src"
 
 # Test the installation
 RUN python3 -c "from nerfgym.NeRFEnv import NeRFEnv"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt update && apt install -y python3 python3-pip git build-essential cmake libpcl-dev liboctomap-dev libeigen3-dev pybind11-dev libfcl-dev libccd-dev
+
+
+# Clone the repository
+RUN git clone https://github.com/SplatLearn/SplatGym.git
+RUN git clone https://github.com/SplatLearn/collision_detector.git
+
+# Build the collision detector
+RUN mkdir -p collision_detector/build && cd collision_detector/build && cmake ../pcd2bt && make -j
+
+# Install the requirements
+RUN pip3 install -r SplatGym/requirements.txt
+
+# Test the installation
+RUN python3 -c "from nerfgym.NeRFEnv import NeRFEnv"

--- a/README.md
+++ b/README.md
@@ -41,26 +41,58 @@ It has the following main features:
   </a>
 </p>
 
-## Usage
+## Installation
 
-First, install dependencies:
+### Docker Container
 
-```sh
+To run a pre-built image:
+
+```bash
+docker run --gpus all \
+            -u $(id -u):$(id -u) \
+            -v /folder/of/your/data:/workspace/ \
+            -v /home/$USER/.cache/:/home/user/.cache/ \
+            -p 7007:7007 \
+            --rm \
+            -it \
+            --shm-size=12gb \
+            docker.io/liyouzhou/splat_gym:latest
+```
+
+To build image from scratch, run the following command at the root of this repository:
+
+```bash
+docker build .
+```
+
+### Native Installation
+
+First, install nerfstudio and its dependencies by following this [guide](https://docs.nerf.studio/quickstart/installation.html). This project uses nerfstudio `1.1.3`. Then run the following command:
+
+```bash
+> sudo apt-get install swig
 > pip install -r src/requirements.txt
 ```
 
-Refer to [collision_detector](https://github.com/SplatLearn/collision_detector) to build the collision detector for your architecture.
-Copy the artifacts to `src/nerfgym/pybind_collision_detector.cpython-<version>-<arch>-<os>.so`
+Refer to [collision_detector](https://github.com/SplatLearn/collision_detector) to build the collision detector for your architecture. In your build folder, your should now have a `pybind_collision_detector.cpython-<version>-<arch>-<os>.so` file.
+
+Now set PYTHONPATH to allow python to find all splat gym modules
+
+```bash
+> export PYTHONPATH="<path to collision_detector>/build:<path to SplatGym>/src":$PYTHONPATH
+```
+
+## Usage
 
 To use the gym environment, a scene must be trained using nerfstudio
 
-```sh
+```bash
 > ns-train splatfacto --data <data_folder>
 ```
 
 Point cloud must be obtained for the scene
 
-```sh
+```bash
 > ns-train nerfacto --data <data_folder> --pipeline.model.predict-normals=True
 > ns-export pointcloud --load-config <nerfacto config> --output-dir <output_dir> 
 ```
@@ -80,5 +112,5 @@ The environment follows the [Gymnasium Env API](https://gymnasium.farama.org/api
 A training script has been written to use PPO to solve the free space navigation problem. This can be invoked:
 
 ```sh
-> PYTHONPATH=<repo_dir>/src  python3 src/training.py train --num_training_steps 300000 --env_id free
+> python3 src/training.py train --num_training_steps 300000 --env_id free
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ attrs==23.2.0
 av==12.2.0
 awscli==1.33.27
 Babel==2.15.0
-backcall @ file:///home/ktietz/src/ci/backcall_1611930011877/work
+backcall==0.2.0
 beautifulsoup4==4.12.3
 bidict==0.23.1
 black==24.8.0
@@ -94,11 +94,11 @@ jsonpointer==3.0.0
 jsonschema==4.23.0
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
+jupyter_client==8.6.0
 jupyter-console==6.6.3
+jupyter_core==5.5.0
 jupyter-events==0.10.0
 jupyter-lsp==2.2.5
-jupyter_client==8.6.0
-jupyter_core==5.5.0
 jupyter_server==2.14.2
 jupyter_server_terminals==0.5.3
 jupyterlab==4.2.4
@@ -124,6 +124,7 @@ mistune==3.0.2
 mpmath==1.3.0
 msgpack==1.0.8
 msgpack-numpy==0.4.8
+msgspec==0.18.6
 multiprocess==0.70.16
 mypy-extensions==1.0.0
 nbclient==0.10.0
@@ -162,18 +163,20 @@ parso==0.8.3
 pathos==0.3.2
 pathspec==0.12.1
 patsy==0.5.3
-pexpect @ file:///tmp/build/80754af9/pexpect_1605563209008/work
-pickleshare @ file:///tmp/build/80754af9/pickleshare_1606932040724/work
+pexpect==4.8.0
+pickleshare==0.7.5
 pillow==10.4.0
+pip==24.0
 platformdirs==4.0.0
 plotly==5.22.0
+plyfile==1.1
 pox==0.3.4
 ppft==1.7.6.8
 prometheus_client==0.20.0
 prompt-toolkit==3.0.40
 protobuf==3.20.3
 psutil==5.9.6
-ptyprocess @ file:///tmp/build/80754af9/ptyprocess_1609355006118/work/dist/ptyprocess-0.7.0-py2.py3-none-any.whl
+ptyprocess==0.7.0
 pure-eval==0.2.2
 pyasn1==0.6.0
 pybind11==2.13.1
@@ -181,7 +184,8 @@ pycocotools==2.0.8
 pycollada==0.8
 pycparser==2.22
 pydot==1.4.2
-pygame==2.5.2
+pygame==2.6.0
+pygbag==0.9.2
 Pygments==2.16.1
 pyliblzfse==0.4.1
 pymeshlab==2023.12.post1
@@ -208,6 +212,7 @@ retrying==1.3.4
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rich==13.7.1
+robot_descriptions==1.12.0
 rpds-py==0.19.0
 rsa==4.7.2
 Rtree==1.3.0
@@ -220,16 +225,15 @@ semantic-version==2.10.0
 Send2Trash==1.8.3
 sentry-sdk==2.10.0
 setproctitle==1.3.3
+setuptools==71.0.1
 shapely==2.0.5
 shtab==1.7.1
 simple-websocket==1.0.0
 simplejson==3.19.2
-six @ file:///tmp/build/80754af9/six_1644875935023/work
-sklearn==0.0.post11
+six==1.16.0
 smmap==5.0.1
 sniffio==1.3.1
 soupsieve==2.5
-splatfacto-w @ git+https://github.com/KevinXu02/splatfacto-w@a72cd926705004fd5743f916c22f327a2e5868e5
 splines==0.3.0
 stable_baselines3==2.3.2
 stack-data==0.6.3
@@ -246,7 +250,7 @@ threadpoolctl==3.2.0
 tifffile==2024.7.2
 timm==0.6.7
 tinycss2==1.3.0
-tinycudann @ git+https://github.com/NVlabs/tiny-cuda-nn/@b3473c81396fe927293bdfd5a6be32df8769927c#subdirectory=bindings/torch
+tinycudann==1.7
 tokenize-rt==5.2.0
 tomli==2.0.1
 torch==2.1.2+cu118
@@ -274,6 +278,7 @@ webencodings==0.5.1
 websocket-client==1.8.0
 websockets==12.0
 Werkzeug==3.0.3
+wheel==0.43.0
 widgetsnbextension==4.0.11
 wrapt==1.16.0
 wsproto==1.2.0


### PR DESCRIPTION
Fixes #1 

- Fix requirements.txt to be purely specified by version rather than local files. This is due to a [bug](https://stackoverflow.com/questions/62885911/pip-freeze-creates-some-weird-path-instead-of-the-package-version) in pip freeze. The requirements file is instead created using `pip list --format=freeze > requirements.txt`.
- Add dockerfile and instructions to use a pre-built docker image
- Fix instructions for natively building the stack.
